### PR TITLE
Move clojure doc before arguments in destructuring namespace

### DIFF
--- a/src/clojure/sparkling/destructuring.clj
+++ b/src/clojure/sparkling/destructuring.clj
@@ -13,13 +13,15 @@
 (def second value)
 
 
-(defn first-value-fn [f]
+(defn first-value-fn
   "Wraps a function f so that when the wrapped function is called on a tuple2, f is called with the second element from that tuple."
+  [f]
   (fn [^Tuple2 tuple]
     (f (._1 tuple))))
 
-(defn second-value-fn [f]
+(defn second-value-fn
   "Wraps a function f so that when the wrapped function is called on a tuple2, f is called with the second element from that tuple."
+  [f]
   (fn [^Tuple2 tuple]
     (f (._2 tuple))))
 
@@ -50,8 +52,9 @@
   (fn [^Tuple2 t]
     (f (seq (._1 t)) (seq (._2 t)))))
 
-(defn key-seq-seq-seq-fn [f]
+(defn key-seq-seq-seq-fn
   "wraps a function f [k seq1 seq2 seq3] to untuple a key/value tuple with three partial values all being seqs. Useful e.g. on map after a cogroup with three RDDs."
+  [f]
   (fn [^Tuple2 t]
     (let [k (._1 t)
           v ^Tuple3 (._2 t)]


### PR DESCRIPTION
I realized the clojure doc wasn't showing up on a couple of the functions in destructuring.clj. If this was intentional, feel free to reject. 

Thanks for putting time into this!