### PR TITLE
Added take-ordered

### DIFF
--- a/src/clojure/sparkling/api.clj
+++ b/src/clojure/sparkling/api.clj
@@ -305,6 +305,15 @@
   [rdd cnt]
   (sc/take cnt rdd))
 
+(defn take-ordered
+  "Returns the first N elements from this RDD using the natural ordering of it's elements.
+   When provided a comparator, returns the first N elements from this RDD in the order
+   defined by this comparator."
+  ([rdd cnt]
+    (.takeOrdered rdd cnt))
+  ([rdd cnt ^java.util.Comparator comparator]
+    (.takeOrdered rdd cnt comparator)))
+
 (def partitions sc/partitions)
 
 

--- a/src/clojure/sparkling/serialization.clj
+++ b/src/clojure/sparkling/serialization.clj
@@ -103,7 +103,9 @@
   (register kryo None$)
   (register kryo Nil$)
   (register kryo scala.reflect.ManifestFactory$$anon$10)
-  )
+  (register kryo scala.math.LowPriorityOrderingImplicits$$anon$7)
+  (register kryo scala.math.Ordering$$anon$4)
+  (register kryo org.spark-project.guava.collect.NaturalOrdering))
 
 (defn register-spark [^Kryo kryo]
   (register-array-type kryo CompactBuffer)

--- a/test/sparkling/api_test.clj
+++ b/test/sparkling/api_test.clj
@@ -522,6 +522,12 @@
                              [1 2 3])))
 
                     (testing
+                      "take-ordered returns the first N elements of an RDD using the natural ordering"
+                      (is (= (-> (s/parallelize c [0 2 1 3 4 5 4])
+                                 (s/take-ordered 3))
+                             [0 1 2])))
+
+                    (testing
                       "glom returns an RDD created by coalescing all elements within each partition into a list"
                       (is (equals-ignore-order? (-> (s/parallelize c [1 2 3 4 5 6 7 8 9 10] 2)
                                                     s/glom


### PR DESCRIPTION
Hi Chris,

I added take-ordered to sparkling.api. I also fiddled with additional test which accepts comparator but couldn't make it work due to serialization issues. You can see what I tried [here](https://github.com/erasmas/sparkling/commit/4ea1cd849e1a75aa8fc5f82634ee495f2993ee94). Hope that helps.