### PR TITLE
wrap RDD fns zip-with-index and zip-with-unique-id

### DIFF
--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -242,6 +242,8 @@ Sparkling supports the following RDD transformations:
 * `group-by`: returns an RDD of items grouped by the return value of a function.
 * `group-by-key`: groups the values for each key in an RDD into a single sequence.
 * `flat-map-to-pair`: returns a new `JavaPairRDD` by first applying a function to all elements of the RDD, and then flattening the results.
+* `zip-with-index`: when called on and RDD of type T, returns a new  `JavaPairRDD` of (T, index) pairs where the index is a `long` element index,  starting from 0.
+* `zip-with-index`: when called on and RDD of type T, returns a new `JavaPairRDD` of (T, id) pairs where the id is a unique `long`.  Items in the kth partition will get ids k, n+k, 2*n+k, ..., where n is the number of partitions. So there may exist gaps, but this method won't trigger a spark job.
 
 
 

--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -243,7 +243,7 @@ Sparkling supports the following RDD transformations:
 * `group-by-key`: groups the values for each key in an RDD into a single sequence.
 * `flat-map-to-pair`: returns a new `JavaPairRDD` by first applying a function to all elements of the RDD, and then flattening the results.
 * `zip-with-index`: when called on and RDD of type T, returns a new  `JavaPairRDD` of (T, index) pairs where the index is a `long` element index,  starting from 0.
-* `zip-with-index`: when called on and RDD of type T, returns a new `JavaPairRDD` of (T, id) pairs where the id is a unique `long`.  Items in the kth partition will get ids k, n+k, 2*n+k, ..., where n is the number of partitions. So there may exist gaps, but this method won't trigger a spark job.
+* `zip-with-unique-id`: when called on and RDD of type T, returns a new `JavaPairRDD` of (T, id) pairs where the id is a unique `long`.  Items in the kth partition will get ids k, n+k, 2*n+k, ..., where n is the number of partitions. So there may exist gaps, but this method won't trigger a spark job.
 
 
 

--- a/src/clojure/sparkling/api.clj
+++ b/src/clojure/sparkling/api.clj
@@ -245,6 +245,12 @@
   ([rdd n shuffle?]
     (sc/coalesce n shuffle? rdd)))
 
+(def zip-with-index
+  sc/zip-with-index)
+
+(def zip-with-unique-id
+  sc/zip-with-index)
+
 (defn repartition
   "Returns a new `rdd` with exactly `n` partitions."
   [rdd n]

--- a/src/clojure/sparkling/core.clj
+++ b/src/clojure/sparkling/core.clj
@@ -392,6 +392,18 @@
      (.coalesce rdd (min n (count-partitions rdd)) shuffle?) n shuffle?)))
 
 
+(defn zip-with-index
+  "Zips this RDD with its element indices, creating an RDD of tuples of (item, index)"
+  [rdd]
+  (u/set-auto-name (.zipWithIndex rdd)))
+
+
+(defn zip-with-unique-id
+  "Zips this RDD with generated unique Long ids, creating an RDD of tuples of (item, uniqueId)"
+  [rdd]
+  (u/set-auto-name (.zipWithUniqueId rdd)))
+
+
 ;; functions on multiple rdds
 
 (defn cogroup


### PR DESCRIPTION
I changed local[*] to local[4] in one of the tests so that partition indexes would be consistent across developers.