### PR TITLE
Correct min partition bug with coalesce-max.

### DIFF
--- a/src/clojure/sparkling/core.clj
+++ b/src/clojure/sparkling/core.clj
@@ -391,10 +391,10 @@
   Useful for running operations more efficiently after filtering down a large dataset."
   ([n rdd]
    (u/set-auto-name
-     (.coalesce rdd (min n (count-partitions rdd))) n))
+     (.coalesce rdd (clojure.core/min n (count-partitions rdd))) n))
   ([n shuffle? rdd]
    (u/set-auto-name
-     (.coalesce rdd (min n (count-partitions rdd)) shuffle?) n shuffle?)))
+     (.coalesce rdd (clojure.core/min n (count-partitions rdd)) shuffle?) n shuffle?)))
 
 
 (defn zip-with-index

--- a/test/sparkling/core_test.clj
+++ b/test/sparkling/core_test.clj
@@ -84,6 +84,20 @@
                                   [#sparkling/tuple[1 {:id 1 :a 1 :b 2}]
                                    #sparkling/tuple[2 {:id 2 :a 2 :b 2}]
                                    #sparkling/tuple[3 {:id 5 :a 3 :b 1}]])))
+
+      (testing "coalesce"
+        (is (equals-ignore-order? (->> (s/parallelize c [1 2 3 4 5])
+                                       (s/coalesce 1)
+                                       s/collect
+                                       vec)
+                                  [1 2 3 4 5])))
+
+      (testing "coalesce-max"
+        (is (equals-ignore-order? (->> (s/parallelize c [1 2 3 4 5])
+                                       (s/coalesce-max 2)
+                                       s/collect
+                                       vec)
+                                  [1 2 3 4 5])))
       )))
 
 


### PR DESCRIPTION
- call clojure.core/min explicitly in coalesce max
- add unit tests to the core namespace for coalesce/coalesce-max