### PR TITLE
Fix test for Spark 2.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -61,6 +61,13 @@
                                                      [org.apache.spark/spark-mllib_2.10 "2.0.2" ]
                                                      ] }
 
+             :spark-2.1.0  ^{:pom-scope :provided} {:dependencies
+                                                    [[org.apache.spark/spark-core_2.10 "2.1.0"]
+                                                     [com.github.fommil.netlib/all "1.1.2" :extension "pom"]
+                                                     [com.googlecode.matrix-toolkits-java/mtj "1.0.4"]
+                                                     [org.apache.spark/spark-mllib_2.10 "2.1.0" ]
+                                                     ] }
+
              :hadoop-2.6.0 ^{:pom-scope :provided} {:dependencies
                                                     [[org.apache.hadoop/hadoop-client "2.6.0"
                                                       :exclusions [commons-codec org.apache.curator/curator-recipes org.slf4j/slf4j-api com.google.guava/guava io.netty/netty org.apache.curator/curator-framework org.apache.zookeeper/zookeeper]]

--- a/test/sparkling/rdd/jdbc_test.clj
+++ b/test/sparkling/rdd/jdbc_test.clj
@@ -27,6 +27,7 @@
                           (getObject [index]
                             (first @data)
                             ))))
+                    (setFetchSize [x])
                     (setLong [parameterIndex, x])
                     (isClosed [] false)
                     (close [])))


### PR DESCRIPTION
This change fixes an error while running the tests with Spark 2.1.0. Below is the error:

```
lein test sparkling.rdd.jdbc-test
2017-04-11 12:01:07,705  WARN spark.SparkContext:66 - Support for Scala 2.10 is deprecated as of Spark 2.1.0
2017-04-11 12:01:07,789 ERROR executor.Executor:91 - Exception in task 0.0 in stage 0.0 (TID 0)
java.lang.UnsupportedOperationException: setFetchSize
	at sparkling.rdd.jdbc_test.proxy$java.lang.Object$PreparedStatement$a61f0602.setFetchSize(Unknown Source)
	at org.apache.spark.rdd.JdbcRDD$$anon$1.<init>(JdbcRDD.scala:94)
	at org.apache.spark.rdd.JdbcRDD.compute(JdbcRDD.scala:78)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:323)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:287)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
	at org.apache.spark.scheduler.Task.run(Task.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:282)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
2017-04-11 12:01:07,808  WARN scheduler.TaskSetManager:66 - Lost task 0.0 in stage 0.0 (TID 0, localhost, executor driver): java.lang.UnsupportedOperationException: setFetchSize
	at sparkling.rdd.jdbc_test.proxy$java.lang.Object$PreparedStatement$a61f0602.setFetchSize(Unknown Source)
	at org.apache.spark.rdd.JdbcRDD$$anon$1.<init>(JdbcRDD.scala:94)
	at org.apache.spark.rdd.JdbcRDD.compute(JdbcRDD.scala:78)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:323)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:287)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
	at org.apache.spark.scheduler.Task.run(Task.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:282)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

2017-04-11 12:01:07,810 ERROR scheduler.TaskSetManager:70 - Task 0 in stage 0.0 failed 1 times; aborting job

lein test :only sparkling.rdd.jdbc-test/jdbc-test

ERROR in (jdbc-test) (DAGScheduler.scala:1435)
load stuff from jdbc
expected: (= (s/collect (load-jdbc c get-connection "query" 0 10 1)) [{:id-column 1} {:id-column 2} {:id-column 3} {:id-column 4} {:id-column 5} {:id-column 6} {:id-column 7} {:id-column 8} {:id-column 9} {:id-column 10}])
  actual: org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0, localhost, executor driver): java.lang.UnsupportedOperationException: setFetchSize
	at sparkling.rdd.jdbc_test.proxy$java.lang.Object$PreparedStatement$a61f0602.setFetchSize(Unknown Source)
	at org.apache.spark.rdd.JdbcRDD$$anon$1.<init>(JdbcRDD.scala:94)
	at org.apache.spark.rdd.JdbcRDD.compute(JdbcRDD.scala:78)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:323)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:287)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
	at org.apache.spark.scheduler.Task.run(Task.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:282)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

Driver stacktrace:
 at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$failJobAndIndependentStages (DAGScheduler.scala:1435)
    org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply (DAGScheduler.scala:1423)
    org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply (DAGScheduler.scala:1422)
    scala.collection.mutable.ResizableArray$class.foreach (ResizableArray.scala:59)
    scala.collection.mutable.ArrayBuffer.foreach (ArrayBuffer.scala:47)
    org.apache.spark.scheduler.DAGScheduler.abortStage (DAGScheduler.scala:1422)
    org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply (DAGScheduler.scala:802)
    org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply (DAGScheduler.scala:802)
    scala.Option.foreach (Option.scala:236)
    org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed (DAGScheduler.scala:802)
    org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive (DAGScheduler.scala:1650)
    org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive (DAGScheduler.scala:1605)
    org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive (DAGScheduler.scala:1594)
    org.apache.spark.util.EventLoop$$anon$1.run (EventLoop.scala:48)
    org.apache.spark.scheduler.DAGScheduler.runJob (DAGScheduler.scala:628)
    org.apache.spark.SparkContext.runJob (SparkContext.scala:1918)
    org.apache.spark.SparkContext.runJob (SparkContext.scala:1931)
    org.apache.spark.SparkContext.runJob (SparkContext.scala:1944)
    org.apache.spark.SparkContext.runJob (SparkContext.scala:1958)
    org.apache.spark.rdd.RDD$$anonfun$collect$1.apply (RDD.scala:935)
    org.apache.spark.rdd.RDDOperationScope$.withScope (RDDOperationScope.scala:151)
    org.apache.spark.rdd.RDDOperationScope$.withScope (RDDOperationScope.scala:112)
    org.apache.spark.rdd.RDD.withScope (RDD.scala:362)
    org.apache.spark.rdd.RDD.collect (RDD.scala:934)
    org.apache.spark.api.java.JavaRDDLike$class.collect (JavaRDDLike.scala:361)
    org.apache.spark.api.java.AbstractJavaRDDLike.collect (JavaRDDLike.scala:45)
    sun.reflect.GeneratedMethodAccessor49.invoke (:-1)
    sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    java.lang.reflect.Method.invoke (Method.java:498)
    clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:93)
    clojure.lang.Reflector.invokeInstanceMethod (Reflector.java:28)
    sparkling.core$collect.invoke (core.clj:557)
    sparkling.rdd.jdbc_test/fn (jdbc_test.clj:46)
    clojure.test$test_var$fn__7670.invoke (test.clj:704)
    clojure.test$test_var.invoke (test.clj:704)
    clojure.test$test_vars$fn__7692$fn__7697.invoke (test.clj:722)
    clojure.test$default_fixture.invoke (test.clj:674)
    clojure.test$test_vars$fn__7692.invoke (test.clj:722)
    clojure.test$default_fixture.invoke (test.clj:674)
    clojure.test$test_vars.invoke (test.clj:718)
    clojure.test$test_all_vars.invoke (test.clj:728)
    clojure.test$test_ns.invoke (test.clj:747)
    user$eval87$fn__138.invoke (form-init8522239642442919095.clj:1)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invoke (core.clj:632)
    leiningen.core.injected$compose_hooks$fn__21.doInvoke (form-init8522239642442919095.clj:1)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:630)
    leiningen.core.injected$run_hooks.invoke (form-init8522239642442919095.clj:1)
    leiningen.core.injected$prepare_for_hooks$fn__26$fn__27.doInvoke (form-init8522239642442919095.clj:1)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    clojure.core$map$fn__4553.invoke (core.clj:2624)
    clojure.lang.LazySeq.sval (LazySeq.java:40)
    clojure.lang.LazySeq.seq (LazySeq.java:49)
    clojure.lang.Cons.next (Cons.java:39)
    clojure.lang.RT.next (RT.java:674)
    clojure.core/next (core.clj:64)
    clojure.core$reduce1.invoke (core.clj:909)
    clojure.core$reduce1.invoke (core.clj:900)
    clojure.core$merge_with.doInvoke (core.clj:2936)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.core$apply.invoke (core.clj:632)
    clojure.test$run_tests.doInvoke (test.clj:762)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:630)
    user$eval87$fn__150$fn__181.invoke (form-init8522239642442919095.clj:1)
    user$eval87$fn__150$fn__151.invoke (form-init8522239642442919095.clj:1)
    user$eval87$fn__150.invoke (form-init8522239642442919095.clj:1)
    user$eval87.invoke (form-init8522239642442919095.clj:1)
    clojure.lang.Compiler.eval (Compiler.java:6782)
    clojure.lang.Compiler.eval (Compiler.java:6772)
    clojure.lang.Compiler.load (Compiler.java:7227)
    clojure.lang.Compiler.loadFile (Compiler.java:7165)
    clojure.main$load_script.invoke (main.clj:275)
    clojure.main$init_opt.invoke (main.clj:280)
    clojure.main$initialize.invoke (main.clj:308)
    clojure.main$null_opt.invoke (main.clj:343)
    clojure.main$main.doInvoke (main.clj:421)
    clojure.lang.RestFn.invoke (RestFn.java:421)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.main.main (main.java:37)
Caused by: java.lang.UnsupportedOperationException: setFetchSize
 at sparkling.rdd.jdbc_test.proxy$java.lang.Object$PreparedStatement$a61f0602.setFetchSize (:-1)
    org.apache.spark.rdd.JdbcRDD$$anon$1.<init> (JdbcRDD.scala:94)
    org.apache.spark.rdd.JdbcRDD.compute (JdbcRDD.scala:78)
    org.apache.spark.rdd.RDD.computeOrReadCheckpoint (RDD.scala:323)
    org.apache.spark.rdd.RDD.iterator (RDD.scala:287)
    org.apache.spark.scheduler.ResultTask.runTask (ResultTask.scala:87)
    org.apache.spark.scheduler.Task.run (Task.scala:99)
    org.apache.spark.executor.Executor$TaskRunner.run (Executor.scala:282)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1142)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:617)
    java.lang.Thread.run (Thread.java:745)
```