### PR TITLE
Added basic support for SparkSession API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,40 @@ _site/*
 _source/*
 _cache
 Gemfile.lock
+
+#********** osx template********** 
+
+.DS_Store
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+ 
+
+#********** emacs template********** 
+
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+ 
+
+#********** clojure template********** 
+
+pom.xml
+*jar
+/lib/
+/classes/
+.lein-deps-sum
+ 

--- a/src/clojure/sparkling/session.clj
+++ b/src/clojure/sparkling/session.clj
@@ -1,0 +1,153 @@
+(ns sparkling.session
+  "Spark Session API for Clojure.  SparkSession is a unified entry point, combining
+   SQLContext and HiveContext"
+  (:require [sparkling.core :as spark])
+  (:import [org.apache.spark.sql SparkSession SparkSession$Builder]
+           [org.apache.spark.sql RowFactory]
+           [org.apache.spark.sql.types DataTypes])
+  (:gen-class))
+
+(def schema-types {:binary DataTypes/BinaryType
+                   :boolean DataTypes/BooleanType
+                   :byte DataTypes/ByteType
+                   :date DataTypes/DateType
+                   :double DataTypes/DoubleType
+                   :float DataTypes/FloatType
+                   :integer DataTypes/IntegerType
+                   :long DataTypes/LongType
+                   :null DataTypes/NullType
+                   :short DataTypes/ShortType
+                   :string DataTypes/StringType
+                   :timestamp DataTypes/TimestampType})
+
+(defn spark-session
+  "create a new SparkSession, re-using existing SparkContext if possible"
+  [spark-conf]
+  (-> (SparkSession/builder)
+      (.config spark-conf)
+      (.getOrCreate)))
+
+(defn read-json
+  "Reads a JSON data file, returning a DataFrame"
+  [spark-session file-path]
+  (-> spark-session
+      (.read)
+      (.json file-path)))
+
+(defn read-parquet
+  "Reads a Parquet data file, returning a DataFrame"
+  [spark-session file-path]
+  (-> spark-session
+      (.read)
+      (.parquet file-path)))
+
+(defn write-parquet
+  "Serializes a DataFrame as a Parquet file"
+  [data-frame file-path]
+  (-> data-frame
+      (.write)
+      (.format "parquet")
+      (.save file-path)))
+
+(defn print-schema
+  "Print the schema of the DataFrame to standard out"
+  [data-frame]
+  (.printSchema data-frame))
+
+(defn print-data
+  "Prints the contents of a DataFrame to standard out"
+  [data-frame]
+  (.show data-frame))
+
+(defn register-temp-table
+  "Registers data frame as a temp table, making it queryable with SQL"
+  [data-frame table-name]
+  (.registerTempTable data-frame table-name)
+  data-frame)
+
+(defn run-query
+  "Executes a SQL query against the current SparkSession"
+  [spark-session sql-string]
+  (.sql spark-session sql-string))
+
+(defn row->map-fn
+  "Converts Spark Row to Clojure map using specified schema"
+  [schema]
+  (let [fields (into [] (.fieldNames schema))
+        offsets (range 0 (count fields))
+        field-offsets (map vector fields offsets)]
+    (fn [row]
+      (->> (map #(vector (keyword (first %)) (.get row (second %))) field-offsets)
+           (into {})))))
+
+(defn row->vector-fn
+  "Converst Spark Row to Clojure vector using specified schema"
+  [schema]
+  (let [fields (into [] (.fieldNames schema))
+        offsets (range 0 (count fields))]
+    (fn [row]
+      (->> (map #(.get row %) offsets)
+           (into [])))))
+
+(defn select-values
+  "Pulls values from the map, ordered by the keys in the sequence"
+  [m keys]
+  (reduce #(conj %1 (%2 m)) [] keys))
+
+(defn map->row-fn
+  "Converts Clojure map to Spark Row using specified schema"
+  [keys]
+  (fn [data]
+    (->> (select-values data keys)
+         (into-array Object)
+         (RowFactory/create))))
+
+(defn vector->row
+  "Converts Clojure sequence to Spark Row"
+  [data]
+  (->> (into-array Object data)
+       (RowFactory/create)))
+
+(defn data-frame->rdd-of-maps
+  "Converts DataFrame to RDD of Clojure Maps"
+  [data-frame]
+  (let [schema (.schema data-frame)]
+    (spark/map (row->map-fn schema) (.toJavaRDD data-frame))))
+
+(defn data-frame->rdd-of-vectors
+  "Converts DataFrame to RDD of Vectors"
+  [data-frame]
+  (let [schema (.schema data-frame)]
+    (spark/map (row->vector-fn schema) (.toJavaRDD data-frame))))
+
+(defn create-struct-field
+  "Creates a StructField object from tuple of field name, type and nullable boolean"
+  [field-params]
+  (DataTypes/createStructField (name (first field-params))
+                               ((keyword (second field-params)) schema-types)
+                               (last field-params)))
+
+(defn build-schema
+  "Creates a StructType object, which represents a schema. `fields` should be a
+  sequence of vectors containing the field name, the field type and a boolean
+  indicating if the field is nullable"
+  [fields]
+  (let [struct-fields (into [] (map create-struct-field fields))]
+    (DataTypes/createStructType (java.util.ArrayList. struct-fields))))
+
+(defn rdd-of-maps->data-frame
+  "Convert an RDD of Maps to a DataFrame"
+  [spark-session rdd fields]
+  (let [columns (map #(keyword (first %)) fields)
+        schema (build-schema fields)
+        row-rdd (spark/map (map->row-fn columns) rdd)]
+    (.createDataFrame spark-session row-rdd schema)))
+
+(defn rdd-of-vectors->data-frame
+  "Convert an RDD of Vectors to a DataFrame"
+  [spark-session rdd fields]
+  (let [columns (map #(keyword (second %)) fields)
+        schema (build-schema fields)
+        row-rdd (spark/map vector->row rdd)]
+    (.createDataFrame spark-session row-rdd schema)))
+


### PR DESCRIPTION
Added basic support for `SparkSession` API.  The main thing that I needed was support for Parquet serialization and running SQL queries against Parquet-serialized data.  I had some trouble getting the map and reduce functions to work on `DataFrame`, but that was of a secondary concern to me at this point.  I would like to go back and add that support at some point for completeness.

As a work around, I included functions to convert back and forth between DataFrame and an RDD with native Clojure types (needed to convert from Row object to a sequence or map).  This allowed me to use existing `sparkling.core` functions on the data but I'm sure there is added overhead w.r.t. performing this conversion.

Please have a look.  Would love to here any and all suggestions on improving the interface or implementation.  I'm fairly new to Clojure and sure that some of this stuff is not completely idiomatic.  Also, the first time I have used the Java interop, so I'm sure there are places for improvement there as well.

I will be using this in hack week project at work next week so we can see how it works at scale.  So far, seems to work well.  One things I see for potential user error is in creating the schema to convert back from an RDD to DataFrame.  Seems Spark is pretty picky about the typing (got an error that it could not serialize an `int` as `LongType`) which was annoying.  Might be some room for improvement there.