### PR TITLE
add extra arity for save-as-text-file to support codec

### DIFF
--- a/src/clojure/sparkling/api.clj
+++ b/src/clojure/sparkling/api.clj
@@ -267,10 +267,13 @@
 (defn save-as-text-file
   "Writes the elements of `rdd` as a text file (or set of text files)
   in a given directory `path` in the local filesystem, HDFS or any other Hadoop-supported
-  file system. Spark will call toString on each element to convert it to a line of
+  file system. Supports an optional codec class like org.apache.hadoop.io.compress.GzipCodec.
+  Spark will call toString on each element to convert it to a line of
   text in the file."
-  [rdd path]
-  (sc/save-as-text-file path rdd))
+  ([rdd path]
+   (sc/save-as-text-file path rdd))
+  ([rdd path codec-class]
+   (sc/save-as-text-file path rdd codec-class)))
 
 
 (defn persist
@@ -385,4 +388,3 @@
   "This re-keys a pair-rdd by applying the rekey-fn to generate new tuples. However, it does not check whether your new keys would keep the same partitioning, so watch out!!!!"
   [rdd rekey-fn]
   (sc/rekey rekey-fn rdd))
-

--- a/src/clojure/sparkling/core.clj
+++ b/src/clojure/sparkling/core.clj
@@ -613,10 +613,13 @@ so that the wrapped function returns a tuple [f(v),v]"
 (defn save-as-text-file
   "Writes the elements of `rdd` as a text file (or set of text files)
   in a given directory `path` in the local filesystem, HDFS or any other Hadoop-supported
-  file system. Spark will call toString on each element to convert it to a line of
+  file system. Supports an optional codec class like org.apache.hadoop.io.compress.GzipCodec.
+  Spark will call toString on each element to convert it to a line of
   text in the file."
-  [path rdd]
-  (.saveAsTextFile rdd path))
+  ([path rdd]
+    (.saveAsTextFile rdd path))
+  ([path rdd codec-class]
+    (.saveAsTextFile rdd path codec-class)))
 
 
 ;; Histogram related functions

--- a/test/sparkling/api_test.clj
+++ b/test/sparkling/api_test.clj
@@ -914,5 +914,5 @@
          org.apache.hadoop.io.compress.BZip2Codec)
 
 
-        (is (= ["Rec1" "Rec2"]
-               (s/collect (s/text-file c path))))))))
+        (is (equals-ignore-order? ["Rec1" "Rec2"]
+                                  (s/collect (s/text-file c path))))))))

--- a/test/sparkling/api_test.clj
+++ b/test/sparkling/api_test.clj
@@ -7,13 +7,14 @@
             [sparkling.api :as s]
             [sparkling.conf :as conf]
             [sparkling.scalaInterop :as si]
-    ;; this is to have the reader macro sparkling/tuple defined
+            ;; this is to have the reader macro sparkling/tuple defined
             [sparkling.destructuring :as sd]
             [sparkling.serialization :as ser]
             [sparkling.kryoserializer :as ks]
             [sparkling.testutils.records.domain :as domain]
             [sparkling.testutils :refer :all]
-            [sparkling.destructuring :as s-de]))
+            [sparkling.destructuring :as s-de]
+            [clojure.java.io :as io]))
 
 
 
@@ -892,3 +893,26 @@
 
 
 
+(deftest
+  text-file-codec
+
+  (let [conf (-> (conf/spark-conf)
+                 (conf/set-sparkling-registrator)
+                 (conf/set "spark.kryo.registrationRequired" "false")
+                 (conf/master "local[*]")
+                 (conf/app-name "api-test"))
+        path (.getPath (io/file (System/getProperty "java.io.tmpdir")
+                                "test-sparkling" (str (System/currentTimeMillis))))]
+
+    (s/with-context c conf
+      (testing
+          "save as text files support codecs"
+
+        (s/save-as-text-file
+         (s/parallelize c ["Rec1" "Rec2"])
+         path
+         org.apache.hadoop.io.compress.BZip2Codec)
+
+
+        (is (= ["Rec1" "Rec2"]
+               (s/collect (s/text-file c path))))))))


### PR DESCRIPTION
Hi,

This PR allows to use the sparkling api to save text files using for example the `org.apache.hadoop.io.compress.GzipCodec` codec.

* Added extra arity to save-as-text-file
* Added api test for save-as-text-file