### PR TITLE
added spark-session, converts context to spark session

### DIFF
--- a/src/clojure/sparkling/core.clj
+++ b/src/clojure/sparkling/core.clj
@@ -28,6 +28,7 @@
            [org.apache.spark.api.java JavaSparkContext StorageLevels
                                       JavaRDD JavaPairRDD JavaDoubleRDD]
            [org.apache.spark HashPartitioner Partitioner]
+           [org.apache.spark.sql SparkSession]
            [org.apache.spark.rdd PartitionwiseSampledRDD PartitionerAwareUnionRDD]
            [scala.collection JavaConversions]
            [scala.reflect ClassTag$]))
@@ -740,6 +741,10 @@ so that the wrapped function returns a tuple [f(v),v]"
                   (conf/master master)
                   (conf/app-name app-name))]
      (spark-context conf))))
+
+(defn spark-session
+  [^JavaSparkContext context]
+  (SparkSession. (.sc context)))
 
 (defn local-spark-context
   [app-name]

--- a/test/sparkling/core_test.clj
+++ b/test/sparkling/core_test.clj
@@ -10,7 +10,21 @@
             ))
 
 
+(deftest spark-session-test
+  (s/with-context
+    c
+    (-> (conf/spark-conf)
+        (conf/set-sparkling-registrator)
+        (conf/set "spark.kryo.registrationRequired" "true")
+        (conf/master "local[*]")
+        (conf/app-name "api-test"))
+    (let [spark-session (s/spark-session c)
+          df            (.toDF (.range spark-session 10) (into-array String ["number"]))]
+      (testing "checking SparkSession instance"
+        (is (instance? org.apache.spark.sql.SparkSession spark-session)))
 
+      (testing "checking DF instance"
+        (instance? org.apache.spark.sql.Dataset df)))))
 
 (deftest lookup
   (s/with-context


### PR DESCRIPTION
I was reading _Spark: The Definitive Guide_ book and running code snippets with **sparkling**, the book starts code examples with **SparkSession** object so I thought it would be nice to have this **spark-session** fn. Also, it could help newcomers to run code snippets :)