### PR TITLE
Bump spark to 3.2.1 with scala 2.12

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,13 +13,11 @@
                  [com.damballa/parkour "0.6.2" :exclusions [com.thoughtworks.paranamer/paranamer]]
                  [com.damballa/abracad "0.4.12" :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [org.apache.avro/avro-mapred "1.7.7" :scope "provided" :classifier "hadoop2" :exclusions [org.slf4j/slf4j-api io.netty/netty commons-lang org.mortbay.jetty/servlet-api]]
-
-                                        ;[com.esotericsoftware.kryo/kryo "2.24.0" :scope "provided"]
                  ]
 
   :aliases {"all" ["with-profile" "default"]}
 
-  :profiles {:default      [:base :system :user :provided :spark-2.0.2 :dev]
+  :profiles {:default      [:base :system :user :provided :spark-3.2.1 :dev]
              :dev          {:dependencies   [[criterium "0.4.3"]]
                             :plugins        [[lein-dotenv "RELEASE"]
                                              [jonase/eastwood "0.1.4"]
@@ -84,6 +82,15 @@
                                                      [org.apache.spark/spark-mllib_2.10 "2.0.2" ]
                                                      ] }
 
+             :spark-3.2.1  ^{:pom-scope :provided} {:dependencies
+                                                    [
+                                                     [org.apache.spark/spark-core_2.12 "3.2.1"]
+                                                     [org.apache.spark/spark-sql_2.12 "3.2.1"]
+                                                     [com.github.fommil.netlib/all "1.1.2" :extension "pom"]
+                                                     [com.googlecode.matrix-toolkits-java/mtj "1.0.4"]
+                                                     [org.apache.spark/spark-mllib_2.12 "3.2.1" ]
+                                                     [org.apache.hadoop/hadoop-client "3.2.1"]]}
+
 
 
              :test         {:resource-paths ["dev-resources" "data"]
@@ -110,7 +117,6 @@
                                              sparkling.accumulator-test
                                              sparkling.test-registrator
                                              sparkling.serialization-test
-                                        ;sparkling.serialization
                                              sparkling.ml.classification
                                              sparkling.ml.core
                                              sparkling.ml.transform
@@ -124,8 +130,16 @@
           :output-dir                "doc"
           :src-dir-uri               "https://raw.githubusercontent.com/gorillalabs/sparkling/v1.2.2/"
           :src-linenum-anchor-prefix "L"}
-  :javac-options ["-Xlint:unchecked" "-source" "1.6" "-target" "1.7"]
-  :jvm-opts ^:replace ["-server" "-Xmx2g"]
+  :javac-options ["-Xlint:unchecked" "-target" "1.8" "-source" "1.8"]
+  :jvm-opts ^:replace ["-server" "-Xmx2g"
+                       "--add-opens" "java.base/java.net=ALL-UNNAMED"
+                       "--add-opens" "java.base/java.lang=ALL-UNNAMED"
+                       "--add-opens" "java.base/java.util=ALL-UNNAMED"
+                       "--add-opens" "java.base/java.util.concurrent=ALL-UNNAMED"
+                       "--add-opens" "java.base/java.nio=ALL-UNNAMED"
+                       "--add-opens" "java.base/sun.nio.ch=ALL-UNNAMED"
+                       "--add-opens" "java.base/java.lang.invoke=ALL-UNNAMED"
+                       "--add-opens" "java.base/sun.util.calendar=ALL-UNNAMED"]
   :global-vars {*warn-on-reflection* false}
   )
 

--- a/src/clojure/sparkling/accumulator.clj
+++ b/src/clojure/sparkling/accumulator.clj
@@ -1,19 +1,36 @@
 (ns sparkling.accumulator
   (:require [sparkling.scalaInterop :as si])
   (:import [org.apache.spark.api.java JavaSparkContext]
-           [org.apache.spark Accumulator]
-           )
+           [org.apache.spark.util AccumulatorV2])
   (:refer-clojure :exclude [name]))
 
-(defn accumulator
-  ([^JavaSparkContext sc value]
-   (.accumulator sc value))
-  ([^JavaSparkContext sc value name]
-   (.accumulator sc value name)))
+(defn- init-accumulator-to
+  [acc value]
+  (when-not (zero? value)
+    (.add acc value))
+  acc)
 
-(defn value [^Accumulator accumulator-var]
+(defn double-accumulator
+  ([^JavaSparkContext sc value]
+   (-> (.doubleAccumulator (.sc sc))
+       (init-accumulator-to value)))
+  ([^JavaSparkContext sc value name]
+   (-> (.doubleAccumulator (.sc sc) name)
+       (init-accumulator-to value))))
+
+(def accumulator double-accumulator)
+
+(defn long-accumulator
+  ([^JavaSparkContext sc value]
+   (-> (.longAccumulator (.sc sc))
+       (init-accumulator-to value)))
+  ([^JavaSparkContext sc value name]
+   (-> (.longAccumulator (.sc sc) name)
+       (init-accumulator-to value))))
+
+(defn value [^AccumulatorV2 accumulator-var]
   (.value accumulator-var))
 
-(defn name [^Accumulator accumulator-var]
+(defn name [^AccumulatorV2 accumulator-var]
   (let [name-var (.name accumulator-var)]
     (si/some-or-nil name-var)))

--- a/src/clojure/sparkling/serialization.clj
+++ b/src/clojure/sparkling/serialization.clj
@@ -1,14 +1,13 @@
 (ns sparkling.serialization
   (:require [clojure.tools.logging :as log]
             [carbonite.api :as carbonite]
-            [sparkling.core :as core]
             [sparkling.serializers :as serializer])
   (:import [com.twitter.chill Tuple2Serializer Tuple3Serializer]
            [org.objenesis.strategy StdInstantiatorStrategy]
            [org.apache.spark.serializer KryoRegistrator]
            [scala Tuple2 Tuple3 None$]
            [com.esotericsoftware.kryo Kryo Serializer KryoSerializable]
-           [scala.collection.mutable WrappedArray$ofRef ArrayBuffer]
+           [scala.collection.mutable ArrayBuffer]
            [scala.collection.convert Wrappers]
            [java.util ArrayList Currency EnumSet List]
            [clojure.lang RT$DefaultComparator MethodImplCache]
@@ -83,8 +82,6 @@
   )
 
 (defn register-clojure [^Kryo kryo]
-  #_(register kryo AFunction)
-  #_(register kryo clojure.lang.AFunction$1)
   (register kryo MethodImplCache)
   (register kryo RT$DefaultComparator)
   )
@@ -96,14 +93,12 @@
   (register kryo Tuple3 :serializer (Tuple3Serializer.))
   (register-array-type kryo Tuple3)
 
-  (register kryo WrappedArray$ofRef)
   (register kryo ArrayBuffer)
   (register-array-type kryo ArrayBuffer)
-  (register kryo scala.reflect.ClassTag$$anon$1)
-  (register kryo scala.reflect.ManifestFactory$$anon$2)
+  (register kryo scala.reflect.ClassTag$GenericClassTag)
   (register kryo None$)
   (register kryo Nil$)
-  (register kryo scala.reflect.ManifestFactory$$anon$10)
+  (register kryo scala.reflect.ManifestFactory$ObjectManifest)
   (register kryo scala.collection.convert.Wrappers$)
   )
 
@@ -112,9 +107,7 @@
   (register kryo org.apache.spark.util.collection.OpenHashMap$mcJ$sp)
   (register kryo org.apache.spark.util.collection.OpenHashSet)
   (register kryo org.apache.spark.util.collection.OpenHashSet$Hasher)
-  (register kryo org.apache.spark.util.collection.BitSet)
-  (register kryo org.apache.spark.util.collection.OpenHashMap$$anonfun$1)
-  (register kryo org.apache.spark.util.collection.OpenHashMap$$anonfun$2))
+  (register kryo org.apache.spark.util.collection.BitSet))
 
 
 
@@ -163,6 +156,3 @@
             (.printStackTrace e)
             ))
         (throw (RuntimeException. "Failed to register kryo!" e))))))
-
-
-

--- a/src/java/sparkling/serialization/BaseRegistrator.java
+++ b/src/java/sparkling/serialization/BaseRegistrator.java
@@ -10,6 +10,7 @@ import com.twitter.chill.Tuple2Serializer;
 /**
  * @deprecated Use sparkling.serialization instead! See sparkling.serialization-test.
  */
+@Deprecated
 public class BaseRegistrator implements KryoRegistrator {
 
     protected void register(Kryo kryo) {

--- a/test/sparkling/accumulator_test.clj
+++ b/test/sparkling/accumulator_test.clj
@@ -1,5 +1,5 @@
 (ns sparkling.accumulator-test
-  (:import [org.apache.spark Accumulator])
+  (:import [org.apache.spark.util AccumulatorV2])
   (:require [clojure.test :refer :all]
             [sparkling.api :as s]
             [sparkling.conf :as conf]
@@ -16,7 +16,7 @@
       c conf
       (testing
         "gives us an Accumulator Var"
-        (is (= Accumulator (class (ac/accumulator c 0)))))
+        (is (instance? org.apache.spark.util.AccumulatorV2 (ac/accumulator c 0))))
 
       (testing
         "returns a value"
@@ -30,6 +30,32 @@
         "foreach accumulates values"
         (let [a (ac/accumulator c 0.0)]
           (do
-            (-> (s/parallelize c [1. 2. 3. 4. 5.])
+            (-> (s/parallelize c [1. 2. 3. 4. 5.5])
                 (s/foreach (fn [x] (.add a x))))
-            (is (= (ac/value a) 15.0))))))))
+            (is (= (ac/value a) 15.5))))))))
+
+(deftest long-accumulator
+  (let [conf (-> (conf/spark-conf)
+                 (conf/master "local[*]")
+                 (conf/app-name "ac-test"))]
+    (s/with-context
+      c conf
+      (testing
+          "gives us an Accumulator Var"
+        (is (instance? org.apache.spark.util.AccumulatorV2 (ac/long-accumulator c 0))))
+
+      (testing
+          "returns a value"
+        (is (= (ac/value (ac/long-accumulator c 0)) 0)))
+
+      (testing
+          "returns a name"
+        (is (= (ac/name (ac/long-accumulator c 0 "n")) "n")))
+
+      (testing
+          "foreach accumulates values"
+        (let [a (ac/long-accumulator c 0)]
+          (do
+            (-> (s/parallelize c [1 2 3 4 5])
+                (s/foreach (fn [x] (.add a x))))
+            (is (= (ac/value a) 15))))))))


### PR DESCRIPTION
Thank you for creating sparkling!

This PR adds support for more recent versions of spark (3):
* All tests are passing
* Tested on AWS EMR 6.5.0
* There are some changes related to the accumulators. Mapped the `accumulator/accumulator` to the `doubleAccumulator` for backward compatibility.

At the moment this change is not backward compatible due to the scala & spark version changes.
Are you happy to publish new versions of this library for spark 3.x?

Cheers,
Olivier